### PR TITLE
Add CODEOWNERS and authors info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# It uses the same pattern rule for gitignore file,
+# see https://git-scm.com/docs/gitignore#_pattern_format.
+
+# Default owners
+* @YGZWQZD
+
+# Semisupervised learning
+lambdaLearn/Algorithm/SemiSupervised/ @lambdaLearn-SemiSupervised


### PR DESCRIPTION
Since it is a library across different domains (ssl, rl, etc.), a `CODEOWNERS` file may be added, so changes related to different parts of the library will be dispatched to different developers for review.

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Authors info will also be added in this PR. 